### PR TITLE
Fix up protos for submission

### DIFF
--- a/proto/signed_transaction.proto
+++ b/proto/signed_transaction.proto
@@ -5,14 +5,11 @@ package io.xpring;
 import "transaction.proto";
 
 // A transaction and associated signature data.
-// Next field: 4
+// Next field: 3
 message SignedTransaction {
     // The underlying transaction associated with the signature.
     Transaction transaction = 1;
 
     // The signature of the transaction in hexadecimal.
     string transaction_signature_hex = 2;
-
-    // The public key of the account which signed the transaction in hexadecimal.
-    string public_key_hex = 3;
 }

--- a/proto/submit_signed_transaction_response.proto
+++ b/proto/submit_signed_transaction_response.proto
@@ -12,8 +12,8 @@ message SubmitSignedTransactionResponse {
   int64 engine_result_code = 2;
 
   // Human-readable explanation of the transaction's preliminary result.
-  string engine_result_message = 3;	
+  string engine_result_message = 3;
 
   // The complete transaction in hex string format
-  string tx_blob = 4;
+  string transaction_blob = 4;
 }

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -23,5 +23,5 @@ message Transaction {
     }
 
     // The public key of the account which signed the transaction in hexadecimal.
-    string public_key_hex = 5;
+    string signing_public_key_hex = 5;
 }

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -6,7 +6,7 @@ import "payment.proto";
 import "xrp_amount.proto";
 
 // A class encompassing all transactions.
-// Next field: 5.
+// Next field: 6.
 message Transaction {
     // The account originating the transaction.
     string account = 1;
@@ -21,4 +21,7 @@ message Transaction {
     oneof transaction_data {
         Payment payment = 4;
     }
+
+    // The public key of the account which signed the transaction in hexadecimal.
+    string public_key_hex = 5;
 }


### PR DESCRIPTION
- `tx_blob` to `transaction_blob` (Terram generally prefers unabbreviated names).
- `signing_pub_key` is part of `Transaction` and gets rolled into the signature.